### PR TITLE
Feature/setup order

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -44,6 +44,12 @@ module ActiveMerchant #:nodoc:
         commit 'SetExpressCheckout', build_setup_request('Sale', money, options)
       end
 
+      def setup_order(money, options = {})
+        requires!(options, :return_url, :cancel_return_url)
+
+        commit 'SetExpressCheckout', build_setup_request('Order', money, options)
+      end
+
       def details_for(token)
         commit 'GetExpressCheckoutDetails', build_get_details_request(token)
       end

--- a/test/remote/gateways/remote_paypal_express_test.rb
+++ b/test/remote/gateways/remote_paypal_express_test.rb
@@ -57,4 +57,16 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:login], transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
+
+  def test_set_express_order
+    @options.update(
+      :return_url => 'http://example.com',
+      :cancel_return_url => 'http://example.com',
+      :email => 'Buyer1@paypal.com'
+    )
+    response = @gateway.setup_order(500, @options)
+    assert response.success?
+    assert response.test?
+    assert !response.params['token'].blank?
+  end
 end


### PR DESCRIPTION
This PR adds a method with `Order` payment action, more information about payment actions can be found [here](https://www.paypal.com/uk/smarthelp/article/what-are-the-differences-between-the-express-checkout-payment-actions-ts1501). This action allows merchants to partially capture payments after shipping individual items.  