### PR TITLE
Patch/add order method

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -66,6 +66,12 @@ module ActiveMerchant #:nodoc:
         commit 'DoExpressCheckoutPayment', build_sale_or_authorization_request('Sale', money, options)
       end
 
+      def order(money, options = {})
+        requires!(options, :token, :payer_id)
+
+        commit 'DoExpressCheckoutPayment', build_sale_or_authorization_request('Order', money, options)
+      end
+
       def store(token, options = {})
         commit 'CreateBillingAgreement', build_create_billing_agreement_request(token, options)
       end

--- a/test/remote/gateways/remote_paypal_express_test.rb
+++ b/test/remote/gateways/remote_paypal_express_test.rb
@@ -48,16 +48,6 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert !response.params['token'].blank?
   end
 
-  def test_transcript_scrubbing
-    transcript = capture_transcript(@gateway) do
-      @gateway.setup_authorization(500, @options)
-    end
-    transcript = @gateway.scrub(transcript)
-
-    assert_scrubbed(@gateway.options[:login], transcript)
-    assert_scrubbed(@gateway.options[:password], transcript)
-  end
-
   def test_set_express_order
     @options.update(
       :return_url => 'http://example.com',
@@ -68,5 +58,15 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert response.success?
     assert response.test?
     assert !response.params['token'].blank?
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.setup_authorization(500, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@gateway.options[:login], transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
   end
 end


### PR DESCRIPTION
Order method allows us to checkout with `Order` payment action. More information about payment actions can be found [here](https://www.paypal.com/uk/smarthelp/article/what-are-the-differences-between-the-express-checkout-payment-actions-ts1501)